### PR TITLE
use new clipboard API in clipboard.py

### DIFF
--- a/metall0id/post/clipboard.py
+++ b/metall0id/post/clipboard.py
@@ -18,10 +18,10 @@ dz> run post.capture.clipboard
     def execute(self, arguments):
         con = self.getContext()
         clip = con.getSystemService(con.CLIPBOARD_SERVICE)
-	clipData = clip.getPrimaryClip()
-	for i in range(0, clipData.getItemCount()):
-		item = clipData.getItemAt(i)
-        	self.stdout.write("[*] Clipboard value: %s\n\n" % item.toString())
+        clip_data = clip.getPrimaryClip()
+        for i in range(0, clip_data.getItemCount()):
+            item = clip_data.getItemAt(i)
+            self.stdout.write("[*] Clipboard value: %s\n\n" % item.toString())
 
 class SetClipboard(Module, common.FileSystem, common.ClassLoader):
 
@@ -36,14 +36,13 @@ dz> run post.perform.setclipboard test123
     license = "BSD (3 clause)"
     path = ["post", "perform"]
     permissions = ["com.mwr.dz.permissions.GET_CONTEXT"]
-    
+
     def add_arguments(self, parser):
         parser.add_argument("text", help="value to set the clipboard to")
 
     def execute(self, arguments):
         con = self.getContext()
         clip = con.getSystemService(con.CLIPBOARD_SERVICE)
-	clipData = self.klass("android.content.ClipData").newPlainText("", arguments.text)
-	clip.setPrimaryClip(clipData)
+        clip_data = self.klass("android.content.clip_data").newPlainText("", arguments.text)
+        clip.setPrimaryClip(clip_data)
         self.stdout.write("[*] Clipboard value set: %s\n\n" % arguments.text)
-            


### PR DESCRIPTION
post.capture.clipboard module displays hash code instead of string value.

```
dz> run post.capture.clipboard
[*] Clipboard value: #<Object -2137068146>
```
Fix makes use of new API to:
- display string value of clipboard in post.capture.clipboard
```
dz> run post.capture.clipboard
[*] Clipboard value: ClipData.Item { T:Hello }
```
- set clipboard value explicitly as text in post.perform.setclipboard



