### PR TITLE
`arguments` arg missing in line 28

### DIFF
--- a/mwrlabs.secure_random
+++ b/mwrlabs.secure_random
@@ -25,7 +25,7 @@ class SecureRandom(Module, common.FileSystem, common.PackageManager, common.Prov
 
     def execute(self, arguments):
         if arguments.package_or_uri != None:
-            self.check_package(arguments.package_or_uri)
+            self.check_package(arguments.package_or_uri, arguments)
 
         else:
             for package in self.packageManager().getPackages(common.PackageManager.GET_PERMISSIONS):


### PR DESCRIPTION
Fix for this error:
```bash
drozer Console (v2.4.4)
dz> run scanner.misc.securerandom -a it.package.name
check_package() takes exactly 3 arguments (2 given)
dz> 
```